### PR TITLE
improve equivalence paritioning test

### DIFF
--- a/application.py
+++ b/application.py
@@ -287,6 +287,10 @@ def upload_strategy():
     name = request.form["strategy_name"]
     if name == "":
         return "Strategy name may not be empty"
+
+    if len(name) >= 50:
+        return "Strategy name should not be greater than 50 characters"
+
     message = check_upload_file(file)
     if message != "OK":
         return message

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -18,12 +18,6 @@
 
 </form>
 
-<!-- Button trigger modal
-<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModal">
-    Launch demo modal
-</button> -->
-
-<!-- Modal -->
 <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
     <div class="modal-dialog" role="document">
       <div class="modal-content">
@@ -44,11 +38,6 @@
     </div>
 </div>
 
-<!-- <div class="container small">
-    {{message}}
-    <pre class="prettyprint"><code>{{report}}</code>
-    </pre>
-</div> -->
 
 <br></br>
 
@@ -85,6 +74,12 @@
         // did not give a name
         if (sname === ""){
             $("#exampleModal .modal-body").text('Strategy name cannot be empty');
+            $('#exampleModal').modal("show");
+            return false;
+        }
+
+        if (sname.length >= 50){
+            $("#exampleModal .modal-body").text('Strategy name should not be greater than 50 characters');
             $('#exampleModal').modal("show");
             return false;
         }

--- a/tests/acceptance/test_upload.py
+++ b/tests/acceptance/test_upload.py
@@ -165,6 +165,56 @@ class TestUpload(TestBase):
         self.assertIn(b"No strategy name specified", response.data,
                       "cannot check no strategy_name field")
 
+    def test_upload_long_strategy_name(self):
+        """
+        The test strategy name is too long
+        """
+        response = self.app.post(
+            "/login",
+            data={
+                "email": "testuser@testuser.com",
+                "password": "testuser"},
+        )
+        self.assertEqual(response.status_code, 302,
+                         "Unable to login for the test user")
+
+        data = {'strategy_name': 'a'*50}
+        with open('tests/uploads/helpers.py', 'rb') as fh:
+            buf = io.BytesIO(fh.read())
+            data['user_file'] = (buf, '')
+        response = self.app.post(
+            "/upload",
+            data=data,
+        )
+
+        self.assertIn(b"Strategy name should not be greater than 50 characters", response.data,
+                      "observed long strategy name")
+
+    def test_upload_very_long_strategy_name(self):
+        """
+        The test strategy name is too long
+        """
+        response = self.app.post(
+            "/login",
+            data={
+                "email": "testuser@testuser.com",
+                "password": "testuser"},
+        )
+        self.assertEqual(response.status_code, 302,
+                         "Unable to login for the test user")
+
+        data = {'strategy_name': 'a'*100}
+        with open('tests/uploads/helpers.py', 'rb') as fh:
+            buf = io.BytesIO(fh.read())
+            data['user_file'] = (buf, '')
+        response = self.app.post(
+            "/upload",
+            data=data,
+        )
+
+        self.assertIn(b"Strategy name should not be greater than 50 characters", response.data,
+                      "observed long strategy name")
+
     def test_upload_empty_file(self):
         """
         special case 1: empty file

--- a/tests/acceptance/test_upload.py
+++ b/tests/acceptance/test_upload.py
@@ -188,7 +188,7 @@ class TestUpload(TestBase):
         )
 
         self.assertIn(b"Strategy name should not be greater than 50 characters", response.data,
-                      "observed long strategy name")
+                      "cannot detect long name")
 
     def test_upload_very_long_strategy_name(self):
         """
@@ -213,7 +213,7 @@ class TestUpload(TestBase):
         )
 
         self.assertIn(b"Strategy name should not be greater than 50 characters", response.data,
-                      "observed long strategy name")
+                      "cannot detect very long name")
 
     def test_upload_empty_file(self):
         """

--- a/tests/acceptance/test_upload.py
+++ b/tests/acceptance/test_upload.py
@@ -15,12 +15,8 @@ class TestUpload(TestBase):
     """
     TestUpload
     """
-    def test_can_access_upload_page(self):
-        """
-        User story:
-        User should be able to upload strategy: go to /upload
-        endpoint
-        """
+
+    def login(self):
         response = self.app.post(
             "/login",
             data={
@@ -30,11 +26,18 @@ class TestUpload(TestBase):
         self.assertEqual(response.status_code, 302,
                          "Unable to login for the test user")
 
+    def test_can_access_upload_page(self):
+        """
+        User story:
+        User should be able to upload strategy: go to /upload
+        endpoint
+        """
+        self.login()
         response = self.app.get(
             "/upload"
         )
         self.assertIn(b"Upload Your File", response.data,
-                      "cannot get to /upload endpoint")        
+                      "cannot get to /upload endpoint")
 
     def test_upload_valid_strategy_and_delete(self):
         """
@@ -48,15 +51,7 @@ class TestUpload(TestBase):
         Investment professionals should be able to delete any strategies/data/results they don’t want anymore.
         '
         """
-        response = self.app.post(
-            "/login",
-            data={
-                "email": "testuser@testuser.com",
-                "password": "testuser"},
-        )
-        self.assertEqual(response.status_code, 302,
-                         "Unable to login for the test user")
-
+        self.login()
         data = {'strategy_name': 'strategy'}
         with open('tests/uploads/helpers.py', 'rb') as fh:
             buf = io.BytesIO(fh.read())
@@ -84,9 +79,9 @@ class TestUpload(TestBase):
 
         if not created:
             assert False, "there is no available spots to create test file"
-        
+
         response = self.app.post(
-            "/upload?test_id="+str(test_id),
+            "/upload?test_id=" + str(test_id),
             data=data,
         )
 
@@ -94,7 +89,7 @@ class TestUpload(TestBase):
                          "User cannot upload a valid file")
         self.assertIn(b"successfully", response.data,
                       "file upload is not shown as successful")
-        
+
         s3_loc = "s3://coms4156-strategies/11/strategy" + str(test_id) + '/helpers.py'
         conn = rds.get_connection()
         strategies = pd.read_sql(
@@ -119,17 +114,8 @@ class TestUpload(TestBase):
         Investment professionals can’t upload invalid strategies and empty data/invalid data files.
         '
         """
-        response = self.app.post(
-            "/login",
-            data={
-                "email": "testuser@testuser.com",
-                "password": "testuser"},
-        )
-        self.assertEqual(response.status_code, 302,
-                         "Unable to login for the test user")
-
-        data = {'strategy_name': 'strategy'}
-        data['user_file'] = (io.BytesIO(b"invalid file"), 'helpers.py')
+        self.login()
+        data = {'strategy_name': 'strategy', 'user_file': (io.BytesIO(b"invalid file"), 'helpers.py')}
         response = self.app.post(
             "/upload",
             data=data,
@@ -144,15 +130,7 @@ class TestUpload(TestBase):
         """
         The test strategy name is not there
         """
-        response = self.app.post(
-            "/login",
-            data={
-                "email": "testuser@testuser.com",
-                "password": "testuser"},
-        )
-        self.assertEqual(response.status_code, 302,
-                         "Unable to login for the test user")
-
+        self.login()
         data = {}  # no strategy name
         with open('tests/uploads/helpers.py', 'rb') as fh:
             buf = io.BytesIO(fh.read())
@@ -169,16 +147,8 @@ class TestUpload(TestBase):
         """
         The test strategy name is too long
         """
-        response = self.app.post(
-            "/login",
-            data={
-                "email": "testuser@testuser.com",
-                "password": "testuser"},
-        )
-        self.assertEqual(response.status_code, 302,
-                         "Unable to login for the test user")
-
-        data = {'strategy_name': 'a'*50}
+        self.login()
+        data = {'strategy_name': 'a' * 50}
         with open('tests/uploads/helpers.py', 'rb') as fh:
             buf = io.BytesIO(fh.read())
             data['user_file'] = (buf, '')
@@ -190,20 +160,27 @@ class TestUpload(TestBase):
         self.assertIn(b"Strategy name should not be greater than 50 characters", response.data,
                       "cannot detect long name")
 
+    def test_upload_normal_length_strategy_name(self):
+        """
+        The test strategy name is too long
+        """
+        self.login()
+        data = {'strategy_name': 'a' * 30}
+        with open('tests/uploads/helpers.py', 'rb') as fh:
+            buf = io.BytesIO(fh.read())
+            data['user_file'] = (buf, '')
+        response = self.app.post(
+            "/upload",
+            data=data,
+        )
+        self.assertEqual(response.status_code, 200, "uploaded valid strategy")
+
     def test_upload_very_long_strategy_name(self):
         """
         The test strategy name is too long
         """
-        response = self.app.post(
-            "/login",
-            data={
-                "email": "testuser@testuser.com",
-                "password": "testuser"},
-        )
-        self.assertEqual(response.status_code, 302,
-                         "Unable to login for the test user")
-
-        data = {'strategy_name': 'a'*100}
+        self.login()
+        data = {'strategy_name': 'a' * 100}
         with open('tests/uploads/helpers.py', 'rb') as fh:
             buf = io.BytesIO(fh.read())
             data['user_file'] = (buf, '')
@@ -224,15 +201,7 @@ class TestUpload(TestBase):
         Investment professionals can’t upload invalid strategies and empty data/invalid data files.   
         '
         """
-        response = self.app.post(
-            "/login",
-            data={
-                "email": "testuser@testuser.com",
-                "password": "testuser"},
-        )
-        self.assertEqual(response.status_code, 302,
-                         "Unable to login for the test user")
-
+        self.login()
         data = {'strategy_name': 'strategy'}
         with open('tests/uploads/helpers.py', 'rb') as fh:
             buf = io.BytesIO(fh.read())
@@ -251,15 +220,7 @@ class TestUpload(TestBase):
         """
         user cannot upload a data without file
         """
-        response = self.app.post(
-            "/login",
-            data={
-                "email": "testuser@testuser.com",
-                "password": "testuser"},
-        )
-        self.assertEqual(response.status_code, 302,
-                         "Unable to login for the test user")
-
+        self.login()
         data = {'strategy_name': 'strategy'}  # no user_file fields
         response = self.app.post(
             "/upload",
@@ -273,15 +234,7 @@ class TestUpload(TestBase):
         """
         strategy name cannot be empty
         """
-        response = self.app.post(
-            "/login",
-            data={
-                "email": "testuser@testuser.com",
-                "password": "testuser"},
-        )
-        self.assertEqual(response.status_code, 302,
-                         "Unable to login for the test user")
-
+        self.login()
         data = {'strategy_name': ''}  # no strategy name
         with open('tests/uploads/helpers.py', 'rb') as fh:
             buf = io.BytesIO(fh.read())


### PR DESCRIPTION
## changlog

added upper bound test for strategy name length

![image](https://user-images.githubusercontent.com/22876277/101432405-cee1e680-38d6-11eb-9f45-3053edc9c954.png)

## coverage
```
utils/mock_historical_data.py                  28      0   100%
utils/rds.py                                   21      0   100%
utils/s3_util.py                               23      0   100%
---------------------------------------------------------------
TOTAL                                        1393    110    92%
```

## pylint

```
└─ $ ▶pylint */*.py --disable=E1101
************* Module env
migrations/env.py:25:0: C0413: Import "from flask import current_app" should be placed at the top of the module (wrong-import-position)
migrations/env.py:71:36: W0621: Redefining name 'context' from outer scope (line 8) (redefined-outer-name)
migrations/env.py:71:36: W0613: Unused argument 'context' (unused-argument)
migrations/env.py:71:45: W0613: Unused argument 'revision' (unused-argument)

------------------------------------------------------------------
Your code has been rated at 9.69/10 (previous run: 9.69/10, +0.00)

```