### PR TITLE
HACK to hot-fix: save oauth issue

### DIFF
--- a/application.py
+++ b/application.py
@@ -148,6 +148,8 @@ def callback():
         current_user.id = int(unique_id)
     else:
         return "User email not available or not verified by Google", 400
+    # WARNING: HACK THIS METHOD
+    unique_id = unique_id[3:]
     user = OAuthUser(
         id_=unique_id, username=user_name, email=user_email, image_file=picture
     )

--- a/application.py
+++ b/application.py
@@ -148,8 +148,6 @@ def callback():
         current_user.id = int(unique_id)
     else:
         return "User email not available or not verified by Google", 400
-    # WARNING: HACK THIS METHOD
-    unique_id = unique_id[3:]
     user = OAuthUser(
         id_=unique_id, username=user_name, email=user_email, image_file=picture
     )

--- a/application.py
+++ b/application.py
@@ -179,19 +179,15 @@ def home():
 
     :return: redirect user to upload page
     """
-    global current_user
     if current_user.is_authenticated:
-        logger.info("here here here")
         conn = rds.get_connection()
         if isinstance(current_user.email, str):
-            logger.info("ordinary user !!!!!!!!!")
             userid = pd.read_sql(
                 f"select id from backtest.user where email = '{current_user.email}';",
                 conn
             )
             current_user.id = int(userid['id'].iloc[0])
         else:
-            logger.info("oauth user !!!!!!!!!")
             current_user.email = str(current_user.email['email'].iloc[0])
             userid = pd.read_sql(
                 f"select id from backtest.OAuth_user where email = '{current_user.email}';",
@@ -785,6 +781,7 @@ def current_user_init():
     
     current_user is a global object
     """
+    conn = rds.get_connection()
     if isinstance(current_user.email, str):
         userid = pd.read_sql(
             f"select id from backtest.user "
@@ -794,7 +791,6 @@ def current_user_init():
         current_user.id = int(userid['id'].iloc[0])
     else:
         current_user.email = str(current_user.email['email'].iloc[0])
-        conn = rds.get_connection()
         userid = pd.read_sql(
             f"select * from backtest.OAuth_user "
             f"where email = '{current_user.email}';",

--- a/tests/acceptance/test_login_logout.py
+++ b/tests/acceptance/test_login_logout.py
@@ -72,7 +72,6 @@ class TestLoginLogout(TestBase):
         self.assertEqual(response.status_code, 200,
                          "Can login the test user with wrong password")
 
-
     def test_admin_login(self):
         """login test users"""
         response = self.app.post(


### PR DESCRIPTION
I have to hack to hotfix this issue as described in detail in issue #133 please do take a look

The hack I use is:
```python
unique_id = unique_id[3:]
```
I has the risk of conflict, but it should be fine for now, for the demo purpose. I have to truncate it to fit in BIGINT
The change I have done is
- change the type of id of user and user_id of strategies table to BIGINT
- delete the foreign key constraint from strategies to user (NOT A GOOD PRACTICE but should be done to allow oauth user)
- deal with current_user for every endpoints for clean this object

@gzhami I did not use your PR. If there is anything I miss, please let me know
@jialiaz3 we need to redesign the table schema
![Dec-09-2020 02-40-39](https://user-images.githubusercontent.com/43714531/101599579-f9f83300-39c7-11eb-9651-cd970ac389c0.gif)
